### PR TITLE
Switch to pathlib and support all audio formats

### DIFF
--- a/plugin/config.py
+++ b/plugin/config.py
@@ -9,8 +9,8 @@ Source schema:
 - display: string used to display in Yomichan. Uses %s for the "DISPLAY" column.
 """
 
-import os
 import json
+from pathlib import Path
 from typing import TypedDict, Final, Type
 
 from .source.jpod import JPodAudioSource
@@ -43,11 +43,11 @@ class JsonConfig(TypedDict):
 
 
 def get_default_config_path():
-    return os.path.join(get_program_root_path(), DEFAULT_CONFIG_FILE_NAME)
+    return get_program_root_path().joinpath(DEFAULT_CONFIG_FILE_NAME)
 
 
 def get_config_path():
-    return os.path.join(get_program_root_path(), CONFIG_FILE_NAME)
+    return get_program_root_path().joinpath(CONFIG_FILE_NAME)
 
 
 def read_config() -> JsonConfig:
@@ -55,7 +55,7 @@ def read_config() -> JsonConfig:
     read default config, unless user config is found
     """
     config_path = get_config_path()
-    if not os.path.isfile(config_path):
+    if not config_path.is_file():
         default_config_path = get_default_config_path()
         with open(default_config_path, encoding="utf-8") as f:
             return json.load(f)

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import http.server
 import json
 import sqlite3
@@ -37,17 +36,29 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         pass
 
     def get_audio(self, media_dir, file_path):
-        audio_file = os.path.join(get_program_root_path(), media_dir, file_path)
-        if not Path(audio_file).is_file():
+        audio_file = media_dir.joinpath(file_path)
+        if not audio_file.is_file():
             self.send_response(400)
             return
 
-        if audio_file.endswith(".mp3"):
+        if audio_file.suffix == (".mp3"):
             self.send_response(200)
             self.send_header("Content-type", "audio/mpeg")
-        elif audio_file.endswith(".aac"):
+        elif audio_file.suffix == (".aac"):
             self.send_response(200)
             self.send_header("Content-type", "audio/aac")
+        elif audio_file.suffix == (".m4a"):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/mp4")
+        elif audio_file.suffix in ('.ogg', '.oga', '.opus'):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/ogg")
+        elif audio_file.suffix == (".flac"):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/flac")
+        elif audio_file.suffix == (".wav"):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/wav")
         else:
             self.send_response(400)
             return
@@ -61,12 +72,25 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         """
         internal testing method, shouldn't be used outside of testing the android db
         """
-        if file_path.endswith(".mp3"):
+        audio_file = Path(file_path)
+        if audio_file.suffix == (".mp3"):
             self.send_response(200)
             self.send_header("Content-type", "audio/mpeg")
-        elif file_path.endswith(".aac"):
+        elif audio_file.suffix == (".aac"):
             self.send_response(200)
             self.send_header("Content-type", "audio/aac")
+        elif audio_file.suffix == (".m4a"):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/mp4")
+        elif audio_file.suffix in ('.ogg', '.oga', '.opus'):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/ogg")
+        elif audio_file.suffix == (".flac"):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/flac")
+        elif audio_file.suffix == (".wav"):
+            self.send_response(200)
+            self.send_header("Content-type", "audio/wav")
         else:
             self.send_response(400)
             return

--- a/plugin/source/audio_source.py
+++ b/plugin/source/audio_source.py
@@ -1,8 +1,8 @@
-import os
 import sqlite3
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final
 
 from urllib.parse import urlunparse
@@ -35,6 +35,26 @@ class AudioSource(ABC):
         """
         pass
 
+    def is_supported_audio_file_ext(self, path):
+        """
+        determine whether a given file path is a valid audio file extension
+        """
+        if not isinstance(path, Path):
+            path = Path(path)
+        if not path.is_file():
+            return False
+        # audio container formats supposedly supported by browsers (excluding webm since it's typically for videos)
+        if not path.suffix.lower() in ['.mp3', '.m4a', '.aac', '.ogg', '.oga', '.opus', '.flac', '.wav']:
+            print(f"({self.__class__.__name__}) skipping non-audio file: {path}")
+            return False
+        return True
+
+    def find_media_files(self):
+        """
+        returns a list of all valid audio files in the media_dir
+        """
+        return filter(self.is_supported_audio_file_ext, self.get_media_dir_path().rglob("*"))
+
     def construct_file_url(self, file_path: str):
         """
         constructs url to get the audio file (as opposed to the url to get audio sources)
@@ -49,5 +69,5 @@ class AudioSource(ABC):
         )
         return urlunparse(parts)
 
-    def get_media_dir_path(self) -> str:
-        return os.path.join(get_program_root_path(), self.data.media_dir)
+    def get_media_dir_path(self) -> Path:
+        return get_program_root_path().joinpath(self.data.media_dir)

--- a/plugin/source/jpod.py
+++ b/plugin/source/jpod.py
@@ -1,5 +1,5 @@
-import os
 import sqlite3
+from pathlib import Path
 from typing import Final
 
 from .audio_source import AudioSource, AudioSourceData
@@ -9,10 +9,7 @@ from ..jp_util import is_kana
 
 class JPodAudioSource(AudioSource):
     def add_entries(self, connection: sqlite3.Connection):
-        program_root_path = get_program_root_path()
-        start = os.path.join(program_root_path, self.data.media_dir)
         cur = connection.cursor()
-
         sql = f"""
         INSERT INTO entries
           (expression, reading, source, file)
@@ -20,39 +17,33 @@ class JPodAudioSource(AudioSource):
           (?,?,?,?)
             """
 
-        for root, _, files in os.walk(start, topdown=False):
-            for name in files:
-                path = os.path.join(root, name)
-                relative_path = os.path.relpath(path, start)
+        for path in self.find_media_files():
+            relative_path = str(path.relative_to(self.get_media_dir_path()))
+            basename_noext = path.stem
+            parts = basename_noext.split(" - ")
 
-                if not name.endswith(".mp3"):
-                    print(
-                        f"({self.__class__.__name__}) skipping non-mp3 file: {relative_path}"
+            # Cannot parse required fields from a filename missing a " - " separator.
+            if len(parts) != 2:
+                print(
+                    f"({self.__class__.__name__}) skipping file without ' - ' sep: {relative_path}"
+                )
+                continue
+
+            # usually, jpod file names are formatted as:
+            # "reading - term.ext"
+            # however, sometimes, the reading section is just the term (even if the term is kanji)
+            reading, expr = parts
+
+            if reading == expr:
+                if is_kana(reading):
+                    # it's likely safe to store kana only words like this
+                    cur.execute(
+                        sql, (reading, reading, self.data.id, relative_path)
                     )
-                    continue
-
-                parts = name.removesuffix(".mp3").split(" - ")
-                if len(parts) != 2:
-                    print(
-                        f"({self.__class__.__name__}) skipping file with ' - ' sep: {relative_path}"
-                    )
-                    continue
-
-                # usually, jpod file names are formatted as:
-                # "reading - term.mp3"
-                # however, sometimes, the reading section is just the term (even if the term is kanji)
-                reading, expr = parts
-
-                if reading == expr:
-                    if is_kana(reading):
-                        # it's likely safe to store kana only words like this
-                        cur.execute(
-                            sql, (reading, reading, self.data.id, relative_path)
-                        )
-                    else:
-                        cur.execute(sql, (reading, None, self.data.id, relative_path))
                 else:
-                    cur.execute(sql, (expr, reading, self.data.id, relative_path))
+                    cur.execute(sql, (reading, None, self.data.id, relative_path))
+            else:
+                cur.execute(sql, (expr, reading, self.data.id, relative_path))
 
         cur.close()
         connection.commit()

--- a/plugin/source/nhk16.py
+++ b/plugin/source/nhk16.py
@@ -1,4 +1,3 @@
-import os
 import json
 import sqlite3
 from pathlib import Path
@@ -13,188 +12,176 @@ num2fullwidth = str.maketrans("0123456789", "０１２３４５６７８９")
 
 num_map = {0: "零", 1: "一", 2: "二", 3: "三", 4: "四", 5: "五", 6: "六", 7: "七", 8: "八", 9: "九", 10: "十", 11: "十一", 12: "十二", 13: "十三", 14: "十四", 15: "十五", 16: "十六", 17: "十七", 18: "十八", 19: "十九", 20: "二十", 21: "二十一", 22: "二十二", 23: "二十三", 24: "二十四", 25: "二十五", 26: "二十六", 27: "二十七", 28: "二十八", 29: "二十九", 30: "三十", 31: "三十一", 32: "三十二", 33: "三十三", 34: "三十四", 35: "三十五", 36: "三十六", 37: "三十七", 38: "三十八", 39: "三十九", 40: "四十", 41: "四十一", 42: "四十二", 43: "四十三", 44: "四十四", 45: "四十五", 46: "四十六", 47: "四十七", 48: "四十八", 49: "四十九", 50: "五十", 51: "五十一", 52: "五十二", 53: "五十三", 54: "五十四", 55: "五十五", 56: "五十六", 57: "五十七", 58: "五十八", 59: "五十九", 60: "六十", 61: "六十一", 62: "六十二", 63: "六十三", 64: "六十四", 65: "六十五", 66: "六十六", 67: "六十七", 68: "六十八", 69: "六十九", 70: "七十", 71: "七十一", 72: "七十二", 73: "七十三", 74: "七十四", 75: "七十五", 76: "七十六", 77: "七十七", 78: "七十八", 79: "七十九", 80: "八十", 81: "八十一", 82: "八十二", 83: "八十三", 84: "八十四", 85: "八十五", 86: "八十六", 87: "八十七", 88: "八十八", 89: "八十九", 90: "九十", 91: "九十一", 92: "九十二", 93: "九十三", 94: "九十四", 95: "九十五", 96: "九十六", 97: "九十七", 98: "九十八", 99: "九十九", 100: "百", 1000: "千", 10000: "一万"}
 
-
-def get_file_to_relative_path(path):
-    file_to_relpath = {}
-    for root, _, files in os.walk(path):
-        for filename in files:
-            file_path = os.path.join(root, filename)
-            relpath = os.path.relpath(file_path, path)
-            file_to_relpath[filename] = relpath
-    return file_to_relpath
-
-
-def get_numbers(number):
-    if number == "何［ナン］":
-        return ["何"]
-    if int(number) > 100:
-        return [num_map[int(number)]]
-    else:
-        return [f"{number}".translate(num2fullwidth), num_map[int(number)]]
-
-
-def parse_headwords(headword_list, delimiter):
-    kanji_list = []
-    for headword in headword_list:
-        for x in headword.split(delimiter):
-            y = x.strip()
-            if y != "":
-                kanji_list.append(y)
-    return kanji_list
-
-
-
-def get_sound_relpath(accent, file_to_relpath):
-    sound_file = accent["soundFile"]
-    if sound_file is None:
-        return None
-    if sound_file in file_to_relpath:
-        return file_to_relpath[sound_file]
-    else:
-        return None
-
-
-def get_display_text(accent):
-    display_text_list = []
-    pitch_accent_list = []
-    prefix = ""
-    for word_segment in accent["accent"]:
-        pronunciation = word_segment["pronunciation"]
-        pitch_offset = 0
-        if pronunciation == "（温度":
-            continue
-        elif pronunciation.startswith("角度）"):
-            pronunciation = pronunciation.removeprefix("角度）")
-            prefix = "（温度・角度）"
-            pitch_offset = -3
-        elif pronunciation.startswith("（回数）"):
-            pronunciation = pronunciation.removeprefix("（回数）")
-            prefix = "（回数）"
-            pitch_offset = -4
-        mora_list = split_into_mora(pronunciation)
-        for silenced_mora in word_segment["silencedMora"]:
-            index = silenced_mora - 1
-            if len(mora_list) <= index:
-                # there are 59 of these invalid(?) entries.
-                # seem to be mostly in the numbers section.
-                continue
-
-            # This is specifically to differentiate between silenced mora and regular mora,
-            # since it's pretty difficult to represent it any other way in Yomichan
-            mora_list[index] = katakana_to_hiragana(mora_list[index])
-
-        pitch_accent = int(word_segment["pitchAccent"])
-        if pitch_accent + pitch_offset > -1:
-            pitch_accent = pitch_accent + pitch_offset
-        pitch_accent_list.append(f"{pitch_accent}")
-        if pitch_accent > 0:
-            mora_list.insert(pitch_accent, "＼")
-        display_text_list.append("".join(mora_list))
-    display_text = (
-        prefix + f"{'・'.join(display_text_list)} [{'・'.join(pitch_accent_list)}]"
-    )
-    return display_text
-
-
-def insert_entry(conn, entry):
-    cur = conn.cursor()
-
-    sql = 'INSERT INTO entries (expression, reading, source, display, file) VALUES (?,?,?,?,?)'
-    cur.execute(sql, entry)
-
-    cur.close()
-
-
-def add_nhk16_entries(media_dir, conn):
-    program_root_path = get_program_root_path()
-    media_path = os.path.join(program_root_path, media_dir)
-    entries_file = os.path.join(program_root_path, media_dir, "entries.json")
-    if not Path(entries_file).is_file():
-        print(f"(make_nhk16_table) Cannot find entries file: {entries_file}")
-        return
-
-    with open(entries_file, "r", encoding="utf-8", errors="ignore") as f:
-        entries = json.load(f)
-
-    file_to_relpath = get_file_to_relative_path(media_path)
-
-    for entry in entries:
-        reading = entry["kana"]
-        expression_list = parse_headwords(entry["kanji"], "，")
-
-        optional_kanji_list = parse_headwords(entry["kanjiNotUsed"], "，")
-        for optional_kanji in optional_kanji_list:
-            for expression in expression_list:
-                if optional_kanji in expression:
-                    expression_list.remove(expression)
-
-        for accent in entry["accents"]:
-            sound_file = get_sound_relpath(accent, file_to_relpath)
-            if sound_file is None:
-                continue
-            display_text = get_display_text(accent)
-            if len(expression_list) == 0:
-                insert_entry(
-                    conn, (reading, reading, "nhk16", display_text, sound_file)
-                )  # entry
-            for expression in expression_list:
-                insert_entry(
-                    conn, (expression, reading, "nhk16", display_text, sound_file)
-                )  # entry
-
-        for subentry in entry["subentries"]:
-            if "head" in subentry:
-                head_list = parse_headwords([subentry["head"]], "，")
-                for accent in subentry["accents"]:
-                    sound_file = get_sound_relpath(accent, file_to_relpath)
-                    if sound_file is None:
-                        continue
-                    display_text = get_display_text(accent)
-                    for head in head_list:
-                        if is_kana(head):
-                            insert_entry(
-                                conn, (head, head, "nhk16", display_text, sound_file)
-                            )  # subentry
-                        else:
-                            insert_entry(
-                                conn, (head, None, "nhk16", display_text, sound_file)
-                            )  # subentry
-            else:  # number (+counter) section
-                expression_list = parse_headwords(entry["kanji"], "・")
-                numbers = get_numbers(subentry["number"])
-                for accent in subentry["accents"]:
-                    sound_file = get_sound_relpath(accent, file_to_relpath)
-                    if sound_file is None:
-                        continue
-                    display_text = get_display_text(accent)
-                    if reading == "整数":
-                        reading = ""
-                    if len(expression_list) == 0:
-                        for number in numbers:
-                            insert_entry(
-                                conn,
-                                (
-                                    f"{number}{reading}",
-                                    None,
-                                    "nhk16",
-                                    display_text,
-                                    sound_file,
-                                ),
-                            )  # counter
-                    for expression in expression_list:
-                        for number in numbers:
-                            insert_entry(
-                                conn,
-                                (
-                                    f"{number}{expression}",
-                                    None,
-                                    "nhk16",
-                                    display_text,
-                                    sound_file,
-                                ),
-                            )  # counter
-    conn.commit()
-
 class NHK16AudioSource(AudioSource):
-    def add_entries(self, connection: sqlite3.Connection):
-        add_nhk16_entries(self.get_media_dir_path(), connection)
+    # def get_file_to_relative_path(self, path):
+    #     file_to_relpath = {}
+    #     for path in self.find_media_files():
+    #         relative_path = path.relative_to(self.get_media_dir_path())
+    #         file_to_relpath[str(path)] = str(relative_path)
+    #         print(f"file_to_relpath[{str(path)}] = {str(relative_path)}")
+    #     return file_to_relpath
+
+    def get_numbers(self, number):
+        if number == "何［ナン］":
+            return ["何"]
+        if int(number) > 100:
+            return [num_map[int(number)]]
+        else:
+            return [f"{number}".translate(num2fullwidth), num_map[int(number)]]
+
+    def parse_headwords(self, headword_list, delimiter):
+        kanji_list = []
+        for headword in headword_list:
+            for x in headword.split(delimiter):
+                y = x.strip()
+                if y != "":
+                    kanji_list.append(y)
+        return kanji_list
+
+    def get_sound_relpath(self, accent):
+        sound_file = accent["soundFile"]
+        if sound_file is None:
+            return None
+        fullpath = self.get_media_dir_path().joinpath("audio").joinpath(sound_file)
+        relpath = fullpath.relative_to(self.get_media_dir_path())
+        if fullpath.is_file():
+            return str(relpath)
+        else:
+            return None
+
+    def get_display_text(self, accent):
+        display_text_list = []
+        pitch_accent_list = []
+        prefix = ""
+        for word_segment in accent["accent"]:
+            pronunciation = word_segment["pronunciation"]
+            pitch_offset = 0
+            if pronunciation == "（温度":
+                continue
+            elif pronunciation.startswith("角度）"):
+                pronunciation = pronunciation.removeprefix("角度）")
+                prefix = "（温度・角度）"
+                pitch_offset = -3
+            elif pronunciation.startswith("（回数）"):
+                pronunciation = pronunciation.removeprefix("（回数）")
+                prefix = "（回数）"
+                pitch_offset = -4
+            mora_list = split_into_mora(pronunciation)
+            for silenced_mora in word_segment["silencedMora"]:
+                index = silenced_mora - 1
+                if len(mora_list) <= index:
+                    # there are 59 of these invalid(?) entries.
+                    # seem to be mostly in the numbers section.
+                    continue
+
+                # This is specifically to differentiate between silenced mora and regular mora,
+                # since it's pretty difficult to represent it any other way in Yomichan
+                mora_list[index] = katakana_to_hiragana(mora_list[index])
+
+            pitch_accent = int(word_segment["pitchAccent"])
+            if pitch_accent + pitch_offset > -1:
+                pitch_accent = pitch_accent + pitch_offset
+            pitch_accent_list.append(f"{pitch_accent}")
+            if pitch_accent > 0:
+                mora_list.insert(pitch_accent, "＼")
+            display_text_list.append("".join(mora_list))
+        display_text = (
+            prefix + f"{'・'.join(display_text_list)} [{'・'.join(pitch_accent_list)}]"
+        )
+        return display_text
+
+
+    def insert_entry(self, conn, entry):
+        cur = conn.cursor()
+
+        sql = 'INSERT INTO entries (expression, reading, source, display, file) VALUES (?,?,?,?,?)'
+        cur.execute(sql, entry)
+
+        cur.close()
+    def add_entries(self, conn: sqlite3.Connection):
+        media_path = self.get_media_dir_path()
+        entries_file = media_path.joinpath("entries.json")
+
+        if not entries_file.is_file():
+            print(f"(make_nhk16_table) Cannot find entries file: {entries_file}")
+            return
+
+        with open(entries_file, "r", encoding="utf-8", errors="ignore") as f:
+            entries = json.load(f)
+
+        for entry in entries:
+            reading = entry["kana"]
+            expression_list = self.parse_headwords(entry["kanji"], "，")
+
+            optional_kanji_list = self.parse_headwords(entry["kanjiNotUsed"], "，")
+            for optional_kanji in optional_kanji_list:
+                for expression in expression_list:
+                    if optional_kanji in expression:
+                        expression_list.remove(expression)
+
+            for accent in entry["accents"]:
+                sound_file = self.get_sound_relpath(accent)
+                if sound_file is None:
+                    continue
+                display_text = self.get_display_text(accent)
+                if len(expression_list) == 0:
+                    self.insert_entry(
+                        conn, (reading, reading, "nhk16", display_text, sound_file)
+                    )  # entry
+                for expression in expression_list:
+                    self.insert_entry(
+                        conn, (expression, reading, "nhk16", display_text, sound_file)
+                    )  # entry
+
+            for subentry in entry["subentries"]:
+                if "head" in subentry:
+                    head_list = self.parse_headwords([subentry["head"]], "，")
+                    for accent in subentry["accents"]:
+                        sound_file = self.get_sound_relpath(accent)
+                        if sound_file is None:
+                            continue
+                        display_text = self.get_display_text(accent)
+                        for head in head_list:
+                            if is_kana(head):
+                                self.insert_entry(
+                                    conn, (head, head, "nhk16", display_text, sound_file)
+                                )  # subentry
+                            else:
+                                self.insert_entry(
+                                    conn, (head, None, "nhk16", display_text, sound_file)
+                                )  # subentry
+                else:  # number (+counter) section
+                    expression_list = self.parse_headwords(entry["kanji"], "・")
+                    numbers = self.get_numbers(subentry["number"])
+                    for accent in subentry["accents"]:
+                        sound_file = self.get_sound_relpath(accent)
+                        if sound_file is None:
+                            continue
+                        display_text = self.get_display_text(accent)
+                        if reading == "整数":
+                            reading = ""
+                        if len(expression_list) == 0:
+                            for number in numbers:
+                                self.insert_entry(
+                                    conn,
+                                    (
+                                        f"{number}{reading}",
+                                        None,
+                                        "nhk16",
+                                        display_text,
+                                        sound_file,
+                                    ),
+                                )  # counter
+                        for expression in expression_list:
+                            for number in numbers:
+                                self.insert_entry(
+                                    conn,
+                                    (
+                                        f"{number}{expression}",
+                                        None,
+                                        "nhk16",
+                                        display_text,
+                                        sound_file,
+                                    ),
+                                )  # counter
+        conn.commit()

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import NamedTuple
 from dataclasses import dataclass
 
@@ -8,16 +8,16 @@ from .consts import DB_FILE_NAME, ANDROID_DB_FILE_NAME
 
 def get_program_root_path():
     return (
-        os.path.dirname(os.path.realpath(__file__)).replace("\\", "/").removesuffix("/")
+        Path(__file__).parent
     )
 
 
 def get_db_path():
-    return os.path.join(get_program_root_path(), DB_FILE_NAME)
+    return get_program_root_path().joinpath(DB_FILE_NAME)
 
 
 def get_android_db_path():
-    return os.path.join(get_program_root_path(), ANDROID_DB_FILE_NAME)
+    return get_program_root_path().joinpath(ANDROID_DB_FILE_NAME)
 
 
 class URLComponents(NamedTuple):


### PR DESCRIPTION
This moves some of the file listing code to a more generic function shared across all the sources, and ensures that all (browser supported) audio file types are readable by all sources. Additionally, most `os.path` code was changed to `pathlib.Path` due to being more extensible/easier to work with for this purpose.

More changes will probably be needed once we migrate to the new audio sources, but everything has been tested in the latest anki with the currently-supported audio collection (and files converted to opus) and appears to work fine. However, Android stuff is untested.

Closes #10 