### PR TITLE
Fix vocab audio playback for Memento

### DIFF
--- a/plugin/server.py
+++ b/plugin/server.py
@@ -61,7 +61,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
             return
         self.send_response(200)
         self.send_header("Content-type", mime_type)
-        self.send_header('Content-length', str(os.stat(audio_file).st_size))
+        self.send_header("Content-length", str(os.stat(audio_file).st_size))
         self.end_headers()
 
         with open(audio_file, "rb") as fh:

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -4,6 +4,7 @@ import http.server
 import json
 import sqlite3
 import threading
+import os
 
 from http import HTTPStatus
 from urllib.parse import unquote
@@ -60,6 +61,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
             return
         self.send_response(200)
         self.send_header("Content-type", mime_type)
+        self.send_header('Content-length', str(os.stat(audio_file).st_size))
         self.end_headers()
 
         with open(audio_file, "rb") as fh:


### PR DESCRIPTION
When lookup up a word in Memento, the little speaker icon did nothing (because I use no other audio sources). This seems to fix it for me.