### PR TITLE
feat: use platform-specific paths when running as a standalone program

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,10 @@ git clone https://github.com/themoeway/local-audio-yomichan.git
 cd local-audio-yomichan
 
 # You must fill `plugin/user_files` with the audio files, like with step 3 of the main instructions.
-# If you are on a *unix OS and you have already setup the Anki add-on, you can run the command below:
-ln -s ~/.local/share/Anki2/addons21/1045800357/user_files ./plugin/user_files
+# You can run one of the following OS-specific commands:
+mklink /d %LOCALAPPDATA%/local-audio-yomichan %APPDATA%/Anki2/addons21/1045800357/user_files # Windows (requires elavated priviledges)
+ln -s ~/.local/share/Anki2/addons21/1045800357/user_files ~/local/share/local-audio-yomichan # Linux
+ln -s ~/Library/Application\ Support/Anki2/addons21/1045800357/user_files ~/Library/Application\ Support/local-audio-yomichan # MacOS
 
 # After filling in `plugin/user_files` with the audio files, you can now run the server.
 # Ensure you have python 3.9 or above.

--- a/plugin/config.py
+++ b/plugin/config.py
@@ -19,7 +19,7 @@ from .source.forvo import ForvoAudioSource
 from .source.ajt_jp import AJTJapaneseSource
 
 from .consts import CONFIG_FILE_NAME, DEFAULT_CONFIG_FILE_NAME
-from .util import get_config_path, get_data_path, get_program_root_path
+from .util import get_config_dir, get_data_dir, get_program_root_dir
 from .source.audio_source import AudioSource, AudioSourceData
 
 
@@ -43,11 +43,11 @@ class JsonConfig(TypedDict):
 
 
 def get_default_config_file():
-    return get_program_root_path().joinpath(DEFAULT_CONFIG_FILE_NAME)
+    return get_program_root_dir().joinpath(DEFAULT_CONFIG_FILE_NAME)
 
 
 def get_config_file():
-    return get_config_path().joinpath(CONFIG_FILE_NAME)
+    return get_config_dir().joinpath(CONFIG_FILE_NAME)
 
 
 def read_config() -> JsonConfig:
@@ -82,7 +82,7 @@ def get_all_sources() -> dict[str, AudioSource]:
         display = source_json["display"]
 
         # checks for source_meta.json
-        source_meta_path = get_data_path() / path / "source_meta.json"
+        source_meta_path = get_data_dir() / path / "source_meta.json"
         if source_meta_path.is_file():
             with open(source_meta_path, encoding="utf-8") as f:
                 source_meta = json.load(f)

--- a/plugin/config.py
+++ b/plugin/config.py
@@ -19,7 +19,7 @@ from .source.forvo import ForvoAudioSource
 from .source.ajt_jp import AJTJapaneseSource
 
 from .consts import CONFIG_FILE_NAME, DEFAULT_CONFIG_FILE_NAME
-from .util import get_program_root_path
+from .util import get_config_path, get_data_path, get_program_root_path
 from .source.audio_source import AudioSource, AudioSourceData
 
 
@@ -42,26 +42,26 @@ class JsonConfig(TypedDict):
     sources: list[JsonConfigSource]
 
 
-def get_default_config_path():
+def get_default_config_file():
     return get_program_root_path().joinpath(DEFAULT_CONFIG_FILE_NAME)
 
 
-def get_config_path():
-    return get_program_root_path().joinpath(CONFIG_FILE_NAME)
+def get_config_file():
+    return get_config_path().joinpath(CONFIG_FILE_NAME)
 
 
 def read_config() -> JsonConfig:
     """
     read default config, unless user config is found
     """
-    default_config_path = get_default_config_path()
-    with open(default_config_path, encoding="utf-8") as f:
+    default_config_file = get_default_config_file()
+    with open(default_config_file, encoding="utf-8") as f:
         config = json.load(f)
 
-    config_path = get_config_path()
+    config_file = get_config_file()
 
-    if config_path.is_file():
-        with open(config_path, encoding="utf-8") as f:
+    if config_file.is_file():
+        with open(config_file, encoding="utf-8") as f:
             user_config = json.load(f)
             for k, v in user_config.items():
                 config[k] = v
@@ -82,7 +82,7 @@ def get_all_sources() -> dict[str, AudioSource]:
         display = source_json["display"]
 
         # checks for source_meta.json
-        source_meta_path = get_program_root_path() / path / "source_meta.json"
+        source_meta_path = get_data_path() / path / "source_meta.json"
         if source_meta_path.is_file():
             with open(source_meta_path, encoding="utf-8") as f:
                 source_meta = json.load(f)
@@ -98,4 +98,3 @@ def get_all_sources() -> dict[str, AudioSource]:
 
 
 ALL_SOURCES = get_all_sources()
-

--- a/plugin/consts.py
+++ b/plugin/consts.py
@@ -1,13 +1,14 @@
 from typing import Final
 
+APP_NAME: Final = "local-audio-yomichan"
 HOSTNAME: Final = "localhost"
 PORT: Final = 5050
-DB_FILE_NAME: Final = "user_files/entries.db"
-ANDROID_DB_FILE_NAME: Final = "user_files/android.db"
-DB_VERSION_FILE_NAME: Final = "user_files/entries_version.txt"
-JMDICT_FORMS_JSON_FILE_NAME: Final = "user_files/jmdict_forms.json"
+DB_FILE_NAME: Final = "entries.db"
+ANDROID_DB_FILE_NAME: Final = "android.db"
+DB_VERSION_FILE_NAME: Final = "entries_version.txt"
+JMDICT_FORMS_JSON_FILE_NAME: Final = "jmdict_forms.json"
 DEFAULT_CONFIG_FILE_NAME: Final = "default_config.json"
-CONFIG_FILE_NAME: Final = "user_files/config.json"
+CONFIG_FILE_NAME: Final = "config.json"
 LATEST_VERSION_FILE_NAME: Final = "version.txt"
 
 ROWID: Final = 0

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from .util import (
     get_android_db_path,
     get_db_path,
+    get_data_path,
     get_program_root_path,
     get_version_file_path,
     QueryComponents,
@@ -108,7 +109,7 @@ def android_write(og_cur, cur):
         source = ALL_SOURCES[source_id]
 
         full_file_path = os.path.join(
-            get_program_root_path(), source.get_media_dir_path(), file_name
+            get_data_path(), source.get_media_dir_path(), file_name
         )
         if not Path(full_file_path).is_file():
             print(f"(android_write) Cannot find file: {full_file_path}")
@@ -150,7 +151,7 @@ def table_must_be_updated():
     # uses a super basic database updating scheme: regenerates the entire thing
     # (it's failsafe!)
 
-    db_version_file = os.path.join(get_program_root_path(), DB_VERSION_FILE_NAME)
+    db_version_file = os.path.join(get_data_path(), DB_VERSION_FILE_NAME)
     latest_version_file = os.path.join(
         get_program_root_path(), LATEST_VERSION_FILE_NAME
     )
@@ -187,7 +188,7 @@ def update_db_version():
     """
     writes the current version to the db version file
     """
-    db_version_file = os.path.join(get_program_root_path(), DB_VERSION_FILE_NAME)
+    db_version_file = os.path.join(get_data_path(), DB_VERSION_FILE_NAME)
     latest_version_file = get_version_file_path()
 
     with open(latest_version_file) as f:
@@ -307,7 +308,7 @@ def fill_jmdict_forms(conn: sqlite3.Connection):
     """
 
     print(f"(init_db) Filling out JMdict forms...")
-    jmdict_forms_file = get_program_root_path().joinpath(JMDICT_FORMS_JSON_FILE_NAME)
+    jmdict_forms_file = get_data_path().joinpath(JMDICT_FORMS_JSON_FILE_NAME)
     if not jmdict_forms_file.is_file():
         return
 
@@ -359,7 +360,7 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
         # - reading: kana only version of expression. If null, then no reading was
         #   available from the source.
         # - source: one of "jpod", "jpod_alternate", "forvo", "nhk16", "shinmeikai8"
-        # - file: file path to the audio, rooted at user_files/MEDIA_FOLDER
+        # - file: file path to the audio, with the root determined by get_data_path()
         #   Allows for easier sorting for more ideal results without post processing
         #   or unions + subqueries.
         # - speaker: contains the forvo username. Null for anything that isn't forvo.

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -13,11 +13,11 @@ from typing import Any, Callable, TypedDict, Optional
 from dataclasses import dataclass, field
 
 from .util import (
-    get_android_db_path,
-    get_db_path,
-    get_data_path,
-    get_program_root_path,
-    get_version_file_path,
+    get_android_db_file,
+    get_db_file,
+    get_data_dir,
+    get_program_root_dir,
+    get_version_file,
     QueryComponents,
 )
 from .jp_util import is_hiragana
@@ -55,8 +55,8 @@ def android_gen():
     generates the android.db file
     """
 
-    original_db_path = get_db_path()
-    android_db_path = get_android_db_path()
+    original_db_path = get_db_file()
+    android_db_path = get_android_db_file()
 
     # literally copy entries.db -> android.db
     shutil.copy(original_db_path, android_db_path)
@@ -109,7 +109,7 @@ def android_write(og_cur, cur):
         source = ALL_SOURCES[source_id]
 
         full_file_path = os.path.join(
-            get_data_path(), source.get_media_dir_path(), file_name
+            get_data_dir(), source.get_media_dir_path(), file_name
         )
         if not Path(full_file_path).is_file():
             print(f"(android_write) Cannot find file: {full_file_path}")
@@ -120,7 +120,7 @@ def android_write(og_cur, cur):
 
 
 def table_exists_and_has_data() -> bool:
-    with sqlite3.connect(get_db_path()) as conn:
+    with sqlite3.connect(get_db_file()) as conn:
         cursor = conn.cursor()
         cursor.execute(
             "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = :name",
@@ -151,9 +151,9 @@ def table_must_be_updated():
     # uses a super basic database updating scheme: regenerates the entire thing
     # (it's failsafe!)
 
-    db_version_file = os.path.join(get_data_path(), DB_VERSION_FILE_NAME)
+    db_version_file = os.path.join(get_data_dir(), DB_VERSION_FILE_NAME)
     latest_version_file = os.path.join(
-        get_program_root_path(), LATEST_VERSION_FILE_NAME
+        get_program_root_dir(), LATEST_VERSION_FILE_NAME
     )
 
     if not os.path.isfile(db_version_file):
@@ -188,8 +188,8 @@ def update_db_version():
     """
     writes the current version to the db version file
     """
-    db_version_file = os.path.join(get_data_path(), DB_VERSION_FILE_NAME)
-    latest_version_file = get_version_file_path()
+    db_version_file = os.path.join(get_data_dir(), DB_VERSION_FILE_NAME)
+    latest_version_file = get_version_file()
 
     with open(latest_version_file) as f:
         ver = f.read().strip()
@@ -308,7 +308,7 @@ def fill_jmdict_forms(conn: sqlite3.Connection):
     """
 
     print(f"(init_db) Filling out JMdict forms...")
-    jmdict_forms_file = get_data_path().joinpath(JMDICT_FORMS_JSON_FILE_NAME)
+    jmdict_forms_file = get_data_dir().joinpath(JMDICT_FORMS_JSON_FILE_NAME)
     if not jmdict_forms_file.is_file():
         return
 
@@ -339,7 +339,7 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
 
     update_db_version()
 
-    original_db_path = get_db_path()
+    original_db_path = get_db_file()
 
     # completely wipes out the file
     try:

--- a/plugin/default_config.json
+++ b/plugin/default_config.json
@@ -3,31 +3,31 @@
     {
       "type": "nhk",
       "id": "nhk16",
-      "path": "user_files/nhk16_files",
+      "path": "nhk16_files",
       "display": "NHK16 %s"
     },
     {
       "type": "ajt_jp",
       "id": "shinmeikai8",
-      "path": "user_files/shinmeikai8_files",
+      "path": "shinmeikai8_files",
       "display": "SMK8 %s"
     },
     {
       "type": "forvo",
       "id": "forvo",
-      "path": "user_files/forvo_files",
+      "path": "forvo_files",
       "display": "Forvo (%s)"
     },
     {
       "type": "jpod",
       "id": "jpod",
-      "path": "user_files/jpod_files",
+      "path": "jpod_files",
       "display": "Jpod101"
     },
     {
       "type": "jpod",
       "id": "jpod_alternate",
-      "path": "user_files/jpod_alternate_files",
+      "path": "jpod_alternate_files",
       "display": "JPod101 Alt"
     }
   ]

--- a/plugin/gui.py
+++ b/plugin/gui.py
@@ -17,7 +17,7 @@ from .db_utils import (
     get_unique_count,
 )
 
-from .util import get_db_path
+from .util import get_db_file
 from .config import ALL_SOURCES
 
 
@@ -120,7 +120,7 @@ def generate_android_database_success(start_time: float):
 
 
 def show_stats():
-    with sqlite3.connect(get_db_path()) as conn:
+    with sqlite3.connect(get_db_file()) as conn:
         count = get_count(conn)
         files_per_source = get_num_files_per_source(conn)
         unique_count = get_unique_count(conn)

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -14,9 +14,9 @@ from pathlib import Path
 
 from .util import (
     QueryComponents,
-    get_db_path,
-    get_android_db_path,
-    get_version_file_path,
+    get_db_file,
+    get_android_db_file,
+    get_version_file,
 )
 from .consts import *
 from .config import ALL_SOURCES
@@ -81,7 +81,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         self.send_header("Content-type", mime_type)
         self.end_headers()
 
-        android_db_path = get_android_db_path()
+        android_db_path = get_android_db_file()
         with sqlite3.connect(android_db_path) as android_connection:
             android_cursor = android_connection.cursor()
             sql = """
@@ -131,7 +131,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         return qcomps
 
     def send_version(self):
-        latest_version_file = get_version_file_path()
+        latest_version_file = get_version_file()
         with open(latest_version_file) as f:
             ver = f.read().strip()
         payload = f"Local Audio Server v{ver}".encode("utf-8")
@@ -170,7 +170,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         qcomps = self.parse_query_components()
 
         audio_sources_json_list = []
-        with sqlite3.connect(get_db_path()) as connection:
+        with sqlite3.connect(get_db_file()) as connection:
             rows = execute_query(connection, qcomps)
             for row in rows:
                 source = row[SOURCE]

--- a/plugin/source/audio_source.py
+++ b/plugin/source/audio_source.py
@@ -8,7 +8,7 @@ from typing import Final
 from urllib.parse import urlunparse
 
 from ..util import (
-    get_program_root_path,
+    get_data_path,
     URLComponents,
 )
 from ..consts import (
@@ -70,4 +70,4 @@ class AudioSource(ABC):
         return urlunparse(parts)
 
     def get_media_dir_path(self) -> Path:
-        return get_program_root_path().joinpath(self.data.media_dir)
+        return get_data_path().joinpath(self.data.media_dir)

--- a/plugin/source/audio_source.py
+++ b/plugin/source/audio_source.py
@@ -8,7 +8,7 @@ from typing import Final
 from urllib.parse import urlunparse
 
 from ..util import (
-    get_data_path,
+    get_data_dir,
     URLComponents,
 )
 from ..consts import (
@@ -70,4 +70,4 @@ class AudioSource(ABC):
         return urlunparse(parts)
 
     def get_media_dir_path(self) -> Path:
-        return get_data_path().joinpath(self.data.media_dir)
+        return get_data_dir().joinpath(self.data.media_dir)

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -11,7 +11,7 @@ from .consts import APP_NAME, DB_FILE_NAME, ANDROID_DB_FILE_NAME, LATEST_VERSION
 
 
 
-def get_program_root_path():
+def get_program_root_dir():
     """
     gets 'plugin' folder in repo, or the add-on ID on AnkiWeb
     """
@@ -20,14 +20,14 @@ def get_program_root_path():
     )
 
 
-def get_anki_data_path():
-    return get_program_root_path() / "user_files"
+def get_anki_data_dir():
+    return get_program_root_dir() / "user_files"
 
 
-get_anki_config_path = get_anki_data_path
+get_anki_config_dir = get_anki_data_dir
 
 
-def _get_win_data_path():
+def _get_win_data_dir():
     csidl_const = 28  # CSIDL_LOCAL_APPDATA
 
     buf = ctypes.create_unicode_buffer(1024)
@@ -42,13 +42,13 @@ def _get_win_data_path():
     return Path(buf.value) / APP_NAME
 
 
-get_win_data_path = lru_cache(maxsize=None)(_get_win_data_path)
+get_win_data_dir = lru_cache(maxsize=None)(_get_win_data_dir)
 
 
-get_win_config_path = get_win_data_path
+get_win_config_dir = get_win_data_dir
 
 
-def get_linux_data_path():
+def get_linux_data_dir():
     xdg = os.environ.get("XDG_DATA_HOME", "")
     if not xdg.strip():
         return Path.home() / ".local" / "share" / APP_NAME
@@ -56,7 +56,7 @@ def get_linux_data_path():
         return Path(xdg) / APP_NAME
 
 
-def get_linux_config_path():
+def get_linux_config_dir():
     xdg = os.environ.get("XDG_CONFIG_HOME", "")
     if not xdg.strip():
         return Path.home() / ".config" / APP_NAME
@@ -64,55 +64,55 @@ def get_linux_config_path():
         return Path(xdg) / APP_NAME
 
 
-def get_mac_data_path():
+def get_mac_data_dir():
     return Path.home() / "Library" / "Application Support" / APP_NAME
 
 
-get_mac_config_path = get_mac_data_path
+get_mac_config_dir = get_mac_data_dir
 
 
-def get_data_path():
+def get_data_dir():
     """
     returns the native, platform-specific directory for the application data directory
     """
     if importlib.util.find_spec("aqt"):
-        return get_anki_data_path()
+        return get_anki_data_dir()
     elif platform.system() == "Windows":
-        return get_win_data_path()
+        return get_win_data_dir()
     elif platform.system() == "Linux":
-        return get_linux_data_path()
+        return get_linux_data_dir()
     elif platform.system() == "Darwin":
-        return get_mac_data_path()
+        return get_mac_data_dir()
     else:
-        return get_anki_data_path()
+        return get_anki_data_dir()
 
 
-def get_config_path():
+def get_config_dir():
     """
     returns the native, platform-specific directory for the application config directory
     """
     if importlib.util.find_spec("aqt"):
-        return get_anki_config_path()
+        return get_anki_config_dir()
     elif platform.system() == "Windows":
-        return get_win_config_path()
+        return get_win_config_dir()
     elif platform.system() == "Linux":
-        return get_linux_config_path()
+        return get_linux_config_dir()
     elif platform.system() == "Darwin":
-        return get_mac_config_path()
+        return get_mac_config_dir()
     else:
-        return get_anki_config_path()
+        return get_anki_config_dir()
 
 
-def get_db_path():
-    return get_data_path().joinpath(DB_FILE_NAME)
+def get_db_file():
+    return get_data_dir().joinpath(DB_FILE_NAME)
 
 
-def get_android_db_path():
-    return get_data_path().joinpath(ANDROID_DB_FILE_NAME)
+def get_android_db_file():
+    return get_data_dir().joinpath(ANDROID_DB_FILE_NAME)
 
 
-def get_version_file_path():
-    return get_program_root_path().joinpath(LATEST_VERSION_FILE_NAME)
+def get_version_file():
+    return get_program_root_dir().joinpath(LATEST_VERSION_FILE_NAME)
 
 
 class URLComponents(NamedTuple):

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -1,8 +1,13 @@
+import importlib.util
+import os
+import platform
+import ctypes
+from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Optional
 from dataclasses import dataclass
 
-from .consts import DB_FILE_NAME, ANDROID_DB_FILE_NAME, LATEST_VERSION_FILE_NAME
+from .consts import APP_NAME, DB_FILE_NAME, ANDROID_DB_FILE_NAME, LATEST_VERSION_FILE_NAME
 
 
 
@@ -15,12 +20,95 @@ def get_program_root_path():
     )
 
 
+def get_anki_data_path():
+    return get_program_root_path() / "user_files"
+
+
+get_anki_config_path = get_anki_data_path
+
+
+def _get_win_data_path():
+    csidl_const = 28  # CSIDL_LOCAL_APPDATA
+
+    buf = ctypes.create_unicode_buffer(1024)
+    windll = getattr(ctypes, "windll")
+    windll.shell32.SHGetFolderPathW(None, csidl_const, None, 0, buf)
+
+    if any(ord(c) > 255 for c in buf):
+        buf2 = ctypes.create_unicode_buffer(1024)
+        if windll.kernel32.GetShortPathNameW(buf.value, buf2, 1024):
+            buf = buf2
+
+    return Path(buf.value) / APP_NAME
+
+
+get_win_data_path = lru_cache(maxsize=None)(_get_win_data_path)
+
+
+get_win_config_path = get_win_data_path
+
+
+def get_linux_data_path():
+    xdg = os.environ.get("XDG_DATA_HOME", "")
+    if not xdg.strip():
+        return Path.home() / ".local" / "share" / APP_NAME
+    else:
+        return Path(xdg) / APP_NAME
+
+
+def get_linux_config_path():
+    xdg = os.environ.get("XDG_CONFIG_HOME", "")
+    if not xdg.strip():
+        return Path.home() / ".config" / APP_NAME
+    else:
+        return Path(xdg) / APP_NAME
+
+
+def get_mac_data_path():
+    return Path.home() / "Library" / "Application Support" / APP_NAME
+
+
+get_mac_config_path = get_mac_data_path
+
+
+def get_data_path():
+    """
+    returns the native, platform-specific directory for the application data directory
+    """
+    if importlib.util.find_spec("aqt"):
+        return get_anki_data_path()
+    elif platform.system() == "Windows":
+        return get_win_data_path()
+    elif platform.system() == "Linux":
+        return get_linux_data_path()
+    elif platform.system() == "Darwin":
+        return get_mac_data_path()
+    else:
+        return get_anki_data_path()
+
+
+def get_config_path():
+    """
+    returns the native, platform-specific directory for the application config directory
+    """
+    if importlib.util.find_spec("aqt"):
+        return get_anki_config_path()
+    elif platform.system() == "Windows":
+        return get_win_config_path()
+    elif platform.system() == "Linux":
+        return get_linux_config_path()
+    elif platform.system() == "Darwin":
+        return get_mac_config_path()
+    else:
+        return get_anki_config_path()
+
+
 def get_db_path():
-    return get_program_root_path().joinpath(DB_FILE_NAME)
+    return get_data_path().joinpath(DB_FILE_NAME)
 
 
 def get_android_db_path():
-    return get_program_root_path().joinpath(ANDROID_DB_FILE_NAME)
+    return get_data_path().joinpath(ANDROID_DB_FILE_NAME)
 
 
 def get_version_file_path():


### PR DESCRIPTION
The program now looks for the appropriate, native and platform-specific paths when reading/writing data and configuration. The `user_files` directory will still be used when running as an Anki plugin.

Example paths from a typical setup:
- Windows: `C:\Users\foobar\AppData\Local\local-audio-yomichan`
- Linux: `/home/foobar/.{local/share,config}/local-audio-yomichan`
- macOS: `/Users/foobar/Library/Application Support/local-audio-yomichan`

Most of the path logic is adapted from the [`platformdirs`](https://github.com/platformdirs/platformdirs) library.

# Motivation

I wanted to distribute `local-audio-yomichan` as a standalone Linux package, but the non-standard path handling makes it hard to do that. Programs don't always have write access to the directory they live in, so this PR makes it so that data and configuration is stored in the appropriate, OS-compliant directories.
