### PR TITLE
Initialize data dir

### DIFF
--- a/plugin/util.py
+++ b/plugin/util.py
@@ -87,6 +87,18 @@ def get_data_dir():
         return get_anki_data_dir()
 
 
+def attempt_init_data_dir():
+    """
+    Create the data directory if it doesn't already exist.
+    """
+    data_dir = get_data_dir()
+    if not os.path.exists(data_dir):
+        try:
+            os.makedirs(data_dir)
+        except OSError as e:
+            raise Exception(f"Failed to create data directory {data_dir}. Error: {e}") from e
+
+
 def get_config_dir():
     """
     returns the native, platform-specific directory for the application config directory

--- a/run_server.py
+++ b/run_server.py
@@ -2,6 +2,7 @@ import socketserver
 from plugin.consts import HOSTNAME, PORT
 from plugin.server import LocalAudioHandler
 from plugin.db_utils import attempt_init_db
+from plugin.util import attempt_init_data_dir
 
 class DebugTCPServer(socketserver.TCPServer):
     # https://stackoverflow.com/a/42147927
@@ -9,6 +10,7 @@ class DebugTCPServer(socketserver.TCPServer):
 
 if __name__ == "__main__":
     # If we're not in Anki, run the server directly and blocking for easier debugging
+    attempt_init_data_dir()
     attempt_init_db()
 
     print("Running local audio server in debug mode...")


### PR DESCRIPTION
The database cannot not be initialized if the data dir doesn't exist. This happened to me on Linux, running the server outside of Anki.

```
python run_server.py 
/home/user/.local/share/local-audio-yomichan/entries.db
Traceback (most recent call last):
  File "/home/user/Documents/japanese/local-audio-yomichan/run_server.py", line 12, in <module>
    attempt_init_db()
  File "/home/user/Documents/japanese/local-audio-yomichan/plugin/db_utils.py", line 182, in attempt_init_db
    if not table_exists_and_has_data():
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/japanese/local-audio-yomichan/plugin/db_utils.py", line 124, in table_exists_and_has_data
    with sqlite3.connect(get_db_file()) as conn:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: unable to open database file
```